### PR TITLE
Auto-approve DangerFullAccess patches on non-sandboxed platforms

### DIFF
--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -53,6 +53,11 @@ pub fn assess_patch_safety(
         // paths outside the project.
         match get_platform_sandbox() {
             Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
+            None if matches!(sandbox_policy, SandboxPolicy::DangerFullAccess) => {
+                SafetyCheck::AutoApprove {
+                    sandbox_type: SandboxType::None,
+                }
+            }
             None => SafetyCheck::AskUser,
         }
     } else if policy == AskForApproval::Never {


### PR DESCRIPTION
## Summary
- auto-approve patches when DangerFullAccess is enabled on platforms without sandbox support

## Testing
- `just fmt`
- `just fix -p codex-core`
- `cargo check -p codex-core`